### PR TITLE
Add project type flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2921,9 +2921,9 @@
       }
     },
     "commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
+      "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ=="
     },
     "compare-versions": {
       "version": "3.6.0",
@@ -5799,6 +5799,12 @@
         "stringify-object": "^3.3.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
         "execa": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dependencies": {
         "chalk": "^4.1.0",
         "clear": "^0.1.0",
-        "commander": "^6.2.0",
+        "commander": "^8.0.0",
         "deepmerge": "^4.2.2",
         "fs-extra": "^9.0.1",
         "ora": "^5.1.0",


### PR DESCRIPTION
Hey there ! Thanks for this tool :)

With the addition of React as a templatable technology, I could no longer use Next.js with custom sources without having to choose the correct app beforehand.

This PR allows the selection of a project type from the command line.

Note, commander was upgraded to v8 to allow the use of the choice parameter on an option. This enables easier validation.