### PR TITLE
fix: filter `none` and `no` answers from `sao`

### DIFF
--- a/src/Helper/plugin/index.ts
+++ b/src/Helper/plugin/index.ts
@@ -50,7 +50,7 @@ export const getPluginsArray: (answers: Record<string, Answer>) => string[] = (
             if (Array.isArray(value)) return [...(acc as string[]), ...value];
             return acc;
         }, [])
-        .filter((value: string) => value !== "none");
+        .filter((value: string) => value !== "none" && value !== "no");
 };
 
 export const getExtend: (


### PR DESCRIPTION
`getPluginsArray` function was only filtering `none` answers but `no` was also used to skip questions in `refine-react` and `refine-nextjs` project types in `superplate-core-plugins` source.