### PR TITLE
fix: remove non-plugin keys from pluginAnswers object

### DIFF
--- a/src/saofile.ts
+++ b/src/saofile.ts
@@ -102,7 +102,12 @@ const saoConfig: GeneratorConfig = {
         const { projectType } = sao.opts.extras;
 
         const pluginAnswers = { ...answers };
+
         delete pluginAnswers.name;
+        delete pluginAnswers.svg;
+        delete pluginAnswers.title;
+        delete pluginAnswers.icon;
+
         const selectedPlugins = getPluginsArray(pluginAnswers);
 
         const extendData = concatExtend(


### PR DESCRIPTION
svg, title, icon fields aren't plugins, so they are deleted from pluginAnswers.