### PR TITLE
fix: missing answers on `ignores` filters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superplate-cli",
-    "version": "1.14.2",
+    "version": "1.15.0",
     "description": "The frontend boilerplate with superpowers",
     "license": "MIT",
     "repository": {

--- a/src/saofile.ts
+++ b/src/saofile.ts
@@ -218,7 +218,7 @@ const saoConfig: GeneratorConfig = {
         const sourcePrompts = require(path.resolve(sourcePath, "prompt.js"));
 
         actionsArray.push(
-            ...selectedPlugins.map((plugin: string) => {
+            ...["_base", ...selectedPlugins].map((plugin: string) => {
                 const customFilters = handleIgnore(
                     sourcePrompts?.ignores ?? [],
                     sao.answers,

--- a/src/saofile.ts
+++ b/src/saofile.ts
@@ -221,7 +221,10 @@ const saoConfig: GeneratorConfig = {
             ...["_base", ...selectedPlugins].map((plugin: string) => {
                 const customFilters = handleIgnore(
                     sourcePrompts?.ignores ?? [],
-                    sao.answers,
+                    {
+                        ...sao.opts.extras.presetAnswers,
+                        ...sao.answers,
+                    },
                     plugin,
                 );
 


### PR DESCRIPTION
- When passing additional answers through presets, they are not provided to the `when` function of `ignores` items. 
- `_base` plugin is not included in actions arrays. 