### PR TITLE
fix: remove prettier organize imports plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,5 @@
     "trailingComma": "all",
     "singleQuote": false,
     "printWidth": 80,
-    "tabWidth": 4,
-    "organizeImportsSkipDestructiveCodeActions": true
+    "tabWidth": 4
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "superplate-cli",
-    "version": "1.14.2",
+    "version": "1.15.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "superplate-cli",
-            "version": "1.13.0",
+            "version": "1.15.1",
             "license": "MIT",
             "dependencies": {
                 "analytics-node": "^6.0.0",
@@ -22,7 +22,6 @@
                 "parse-github-url": "^1.0.2",
                 "path": "^0.12.7",
                 "prettier": "^2.8.4",
-                "prettier-plugin-organize-imports": "^3.2.2",
                 "sao": "^2.0.0-beta.1",
                 "tar": "^4.4.19",
                 "temp": "^0.9.4",
@@ -9070,25 +9069,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/prettier-plugin-organize-imports": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz",
-            "integrity": "sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==",
-            "peerDependencies": {
-                "@volar/vue-language-plugin-pug": "^1.0.4",
-                "@volar/vue-typescript": "^1.0.4",
-                "prettier": ">=2.0",
-                "typescript": ">=2.9"
-            },
-            "peerDependenciesMeta": {
-                "@volar/vue-language-plugin-pug": {
-                    "optional": true
-                },
-                "@volar/vue-typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/pretty-format": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
@@ -11220,6 +11200,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
             "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -18933,12 +18914,6 @@
                 "fast-diff": "^1.1.2"
             }
         },
-        "prettier-plugin-organize-imports": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.2.tgz",
-            "integrity": "sha512-e97lE6odGSiHonHJMTYC0q0iLXQyw0u5z/PJpvP/3vRy6/Zi9kLBwFAbEGjDzIowpjQv8b+J04PDamoUSQbzGA==",
-            "requires": {}
-        },
         "pretty-format": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
@@ -20627,7 +20602,8 @@
         "typescript": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-            "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ=="
+            "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+            "dev": true
         },
         "undefsafe": {
             "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "superplate-cli",
-    "version": "1.15.1",
+    "version": "1.15.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "superplate-cli",
-            "version": "1.15.1",
+            "version": "1.15.2",
             "license": "MIT",
             "dependencies": {
                 "analytics-node": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "parse-github-url": "^1.0.2",
         "path": "^0.12.7",
         "prettier": "^2.8.4",
-        "prettier-plugin-organize-imports": "^3.2.2",
         "sao": "^2.0.0-beta.1",
         "tar": "^4.4.19",
         "temp": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "superplate-cli",
-    "version": "1.15.1",
+    "version": "1.15.2",
     "description": "The frontend boilerplate with superpowers",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
Before
![Screenshot 2023-04-02 at 01 18 33](https://user-images.githubusercontent.com/16444991/229319087-b7473e37-27e2-45f5-a5e8-d16ba54c16fe.png)

After
![Screenshot 2023-04-02 at 01 19 15](https://user-images.githubusercontent.com/16444991/229319093-01e44b09-6d28-490f-8a66-7777333041d0.png)
