### PR TITLE
Fix: Docs, build crash due to Google Analytics configuration

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -43,12 +43,6 @@ const siteConfig = {
       apiKey: '3b7cf26a19755c7de95bcb3632edd314',
       indexName: 'superplate',
     },
-    gtag: {
-      // You can also use your "G-" Measurement ID here.
-      trackingID: "G-DPWSR1T889",
-      // Optional fields.
-      anonymizeIP: true, // Should IPs be anonymized?
-    },
     navbar: {
       title: 'superplate',
       logo: {

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -28,6 +28,12 @@ const siteConfig = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          // You can also use your "G-" Measurement ID here.
+          trackingID: "G-DPWSR1T889",
+          // Optional fields.
+          anonymizeIP: true, // Should IPs be anonymized?
+        },
       },
     ],
   ],


### PR DESCRIPTION
Fix for this [issue](https://github.com/pankod/superplate/issues/384)

Moved gtag configuration from `themeConfig` to `preset-classic`

[Source](https://github.com/facebook/docusaurus/pull/5832) 